### PR TITLE
Fixed error when there are no searchResults

### DIFF
--- a/lib/locale/en_us.dart
+++ b/lib/locale/en_us.dart
@@ -8,6 +8,8 @@ class AppString {
   AppString._();
 
   static const String noSearchQuery = 'No search query';
+  static const String noResultsFound =
+      'No results were found for this search query';
   static const String searchPlaceholderAll = 'Search or paste your link here';
   static const String searchPlaceholder = 'Search...';
   static const String errorInformation = 'Error: ';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -281,19 +281,25 @@ class _HomePageState extends State<HomePage> {
                 const Center(child: ProgressBar()),
               ConnectionState.done => StatefulBuilder(
                   builder: (final context, final StateSetter setState) {
-                    return SearchResult(
-                      result: resultList,
-                      nextButtonEnabled: nextButtonEnabled,
-                      loadMoreCallback: () async {
-                        setState(() => nextButtonEnabled = false);
-                        await youtubeApi
-                            .nextPage()
-                            .then((final nextPage) => setState(() {
-                                  resultList = [...resultList, ...nextPage];
-                                  nextButtonEnabled = true;
-                                }));
-                      },
-                    );
+                    if (resultList.isNotEmpty) {
+                      return SearchResult(
+                        result: resultList,
+                        nextButtonEnabled: nextButtonEnabled,
+                        loadMoreCallback: () async {
+                          setState(() => nextButtonEnabled = false);
+                          await youtubeApi
+                              .nextPage()
+                              .then((final nextPage) => setState(() {
+                                    resultList = [...resultList, ...nextPage];
+                                    nextButtonEnabled = true;
+                                  }));
+                        },
+                      );
+                    } else {
+                      // Return error Widget here
+                      return const SearchError(
+                          errorText: AppString.noResultsFound);
+                    }
                   },
                 ),
             };


### PR DESCRIPTION
Fixes issue where there is a generic null error for when the search query returns no results. A specific SearchError widget is displayed with a message defined in en_us.dart locale